### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,11 +20,11 @@ jobs:
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get changed files
         id: changed_files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
 
       - name: Check if add-on files changed
         id: changed_addons
@@ -52,11 +52,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master
         with:
           path: "./"
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
+        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.21
+        uses: frenck/action-addon-linter@f995494fd84fae6310d23617e66d0e37de4f14eb # v2.21
         with:
           path: "./"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master
         with:
           path: "./"
 
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build and push add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
+        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
         with:
           args: |
             --${{ matrix.arch }} \

--- a/.github/workflows/update-repository.yaml
+++ b/.github/workflows/update-repository.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🚀 Dispatch Repository Updater update signal
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
           repository: stuartparmenter/homeassistant-addons


### PR DESCRIPTION
## Summary
- Replaces all mutable tag/branch references in GitHub Actions workflows with immutable commit SHAs
- Preserves original version tags as inline comments for readability and Dependabot compatibility
- Covers all 4 workflow files: `release.yaml`, `ci.yaml`, `update-repository.yaml`, `lint.yaml`

This is a supply-chain security hardening measure — tags are mutable and can be moved to point at different code, while commit SHAs are immutable.

### Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6.0.2 | `de0fac2e` |
| `home-assistant/actions/helpers/info` | master | `d56d093b` |
| `docker/login-action` | v4.0.0 | `b45d80f8` |
| `home-assistant/builder` | 2026.02.1 | `6cb4fd3d` |
| `tj-actions/changed-files` | v47 | `24d32ffd` |
| `peter-evans/repository-dispatch` | v4 | `28959ce8` |
| `frenck/action-addon-linter` | v2.21 | `f995494f` |

## Test plan
- [ ] Verify CI workflow runs correctly on this PR
- [ ] Confirm Dependabot can still detect and propose action version updates