### PR TITLE
Migrate from deprecated builder to composable actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: CI
 
 env:
-  BUILD_ARGS: "--test"
   MONITORED_FILES: "build.yaml config.yaml Dockerfile run.sh rtl_433.conf.template"
+  ARCHITECTURES: '["amd64", "aarch64"]'
+  IMAGE_NAME: rtl433-addon
 
 on:
   push:
@@ -16,8 +17,11 @@ jobs:
   init:
     runs-on: ubuntu-latest
     name: Initialize builds
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.changed_addons.outputs.changed }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,14 +43,22 @@ jobs:
           echo "No monitored files changed (${{ env.MONITORED_FILES }})";
           echo "changed=false" >> $GITHUB_OUTPUT;
 
+      - name: Get build matrix
+        if: steps.changed_addons.outputs.changed == 'true'
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
+        with:
+          architectures: ${{ env.ARCHITECTURES }}
+          image-name: ${{ env.IMAGE_NAME }}
+
   build:
     needs: init
-    runs-on: ubuntu-latest
     if: needs.init.outputs.changed == 'true'
+    runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.arch }} add-on
     strategy:
-      matrix:
-        arch: ["armhf", "armv7", "aarch64", "amd64", "i386"]
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     permissions:
       contents: read
 
@@ -54,34 +66,26 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master
-        with:
-          path: "./"
-
-      - name: Check if add-on should be built
-        id: check
+      - name: Get build configuration
+        id: config
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          if [[ "${{ steps.info.outputs.image }}" == "null" ]]; then
-            echo "Image property is not defined, skipping build"
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-            echo "build_arch=true" >> $GITHUB_OUTPUT;
-            echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-          else
-            echo "${{ matrix.arch }} is not a valid arch for this add-on, skipping build";
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          fi
+          echo "build_from=$(yq ".build_from.${ARCH}" build.yaml)" >> $GITHUB_OUTPUT
+          echo "librtlsdr_repo=$(yq '.args.librtlsdrRepo' build.yaml)" >> $GITHUB_OUTPUT
+          echo "rtl433_git_revision=$(yq '.args.rtl433GitRevision' build.yaml)" >> $GITHUB_OUTPUT
 
       - name: Build add-on
-        if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
+        uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
         with:
-          args: |
-            ${{ env.BUILD_ARGS }} \
-            --${{ matrix.arch }} \
-            --target /data \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
+          arch: ${{ matrix.arch }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          cosign: "false"
+          image: ${{ matrix.image }}
+          image-tags: test
+          push: "false"
+          version: test
+          build-args: |
+            BUILD_FROM=${{ steps.config.outputs.build_from }}
+            librtlsdrRepo=${{ steps.config.outputs.librtlsdr_repo }}
+            rtl433GitRevision=${{ steps.config.outputs.rtl433_git_revision }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,55 +4,66 @@ on:
   release:
     types: [published]
 
+env:
+  ARCHITECTURES: '["amd64", "aarch64"]'
+  IMAGE_NAME: rtl433-addon
+
+concurrency:
+  group: release-${{ github.ref }}
+
 jobs:
-  release:
+  init:
     runs-on: ubuntu-latest
-    name: Build and publish release
+    name: Initialize build
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Get build matrix
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
+        with:
+          architectures: ${{ env.ARCHITECTURES }}
+          image-name: ${{ env.IMAGE_NAME }}
+
+  build:
+    needs: init
+    runs-on: ${{ matrix.os }}
+    name: Build and publish ${{ matrix.arch }} add-on
     strategy:
-      matrix:
-        arch: ["armhf", "armv7", "aarch64", "amd64", "i386"]
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     permissions:
       contents: read
+      id-token: write
       packages: write
 
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master
-        with:
-          path: "./"
-
-      - name: Check if add-on should be built
-        id: check
+      - name: Get build configuration
+        id: config
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          if [[ "${{ steps.info.outputs.image }}" == "null" ]]; then
-            echo "Image property is not defined, skipping build"
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-            echo "build_arch=true" >> $GITHUB_OUTPUT;
-            echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-          else
-            echo "${{ matrix.arch }} is not a valid arch for this add-on, skipping build";
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          fi
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          echo "build_from=$(yq ".build_from.${ARCH}" build.yaml)" >> $GITHUB_OUTPUT
+          echo "librtlsdr_repo=$(yq '.args.librtlsdrRepo' build.yaml)" >> $GITHUB_OUTPUT
+          echo "rtl433_git_revision=$(yq '.args.rtl433GitRevision' build.yaml)" >> $GITHUB_OUTPUT
+          echo "version=$(yq '.version' config.yaml)" >> $GITHUB_OUTPUT
 
       - name: Build and push add-on
-        if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
+        uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
         with:
-          args: |
-            --${{ matrix.arch }} \
-            --target /data \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
+          arch: ${{ matrix.arch }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          cosign: "true"
+          image: ${{ matrix.image }}
+          image-tags: |
+            ${{ steps.config.outputs.version }}
+            latest
+          push: "true"
+          version: ${{ steps.config.outputs.version }}
+          build-args: |
+            BUILD_FROM=${{ steps.config.outputs.build_from }}
+            librtlsdrRepo=${{ steps.config.outputs.librtlsdr_repo }}
+            rtl433GitRevision=${{ steps.config.outputs.rtl433_git_revision }}

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,6 @@
 build_from:
-  armhf: "ghcr.io/home-assistant/armhf-base-debian:bookworm"
-  armv7: "ghcr.io/home-assistant/armv7-base-debian:bookworm"
   aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
   amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
-  i386: "ghcr.io/home-assistant/i386-base-debian:bookworm"
 args:
   librtlsdrRepo: "https://github.com/librtlsdr/librtlsdr"
   rtl433GitRevision: "25.02"

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ version: "0.1.0"
 slug: rtl433
 description: "Receive wireless sensor data via an SDR dongle and rtl_433"
 url: https://github.com/stuartparmenter/rtl433-addon
-arch: [armhf, armv7, aarch64, amd64, i386]
+arch: [aarch64, amd64]
 image: "ghcr.io/stuartparmenter/{arch}-rtl433-addon"
 init: false
 map: [addon_config:rw]


### PR DESCRIPTION
## Summary

The monolithic `home-assistant/builder` action [is deprecated](https://github.com/home-assistant/builder/releases/tag/2026.03.0) and will be removed soon. This migrates to the new composable actions (`prepare-multi-arch-matrix` + `build-image`), following the same pattern as media-proxy-addon (#17 in that repo).

**Closes PR #12** (which just bumped the deprecated action version)

### Changes

- **CI workflow**: Uses `build-image` for test builds (no push, cosign disabled)
- **Release workflow**: Uses `build-image` with push + cosign keyless signing enabled
- Both workflows use `prepare-multi-arch-matrix` for native ARM runners
- Build config (`BUILD_FROM`, `librtlsdrRepo`, `rtl433GitRevision`) read directly from `build.yaml` via `yq`
- Removed dependency on `home-assistant/actions/helpers/info`
- Dropped `armhf`, `armv7`, `i386` architectures (deprecated/removed)

### Key improvements

- **Native ARM builds** — `aarch64` now builds on `ubuntu-24.04-arm` instead of QEMU emulation
- **GHA build cache** — GitHub Actions cache enabled alongside registry inline cache
- **Cosign signing** — release images are signed with keyless cosign (OIDC via GitHub)
- **Explicit config** — no more opaque CLI flags (`--addon`, `--test`, `--target /data`)

### Image names unchanged

`ghcr.io/stuartparmenter/{arch}-rtl433-addon` — the publish pipeline to `homeassistant-addons` is unaffected.

## Test plan

- [ ] CI workflow runs successfully on this PR (build without push)
- [ ] Verify image names in matrix output match existing convention
- [ ] Close PR #12 after merge