### PR TITLE
Pin build dependencies to SHAs, update rtl_433 to 25.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           echo "build_from=$(yq ".build_from.${ARCH}" build.yaml)" >> $GITHUB_OUTPUT
-          echo "librtlsdr_repo=$(yq '.args.librtlsdrRepo' build.yaml)" >> $GITHUB_OUTPUT
+          echo "librtlsdr_git_revision=$(yq '.args.librtlsdrGitRevision' build.yaml)" >> $GITHUB_OUTPUT
           echo "rtl433_git_revision=$(yq '.args.rtl433GitRevision' build.yaml)" >> $GITHUB_OUTPUT
 
       - name: Build add-on
@@ -87,5 +87,5 @@ jobs:
           version: test
           build-args: |
             BUILD_FROM=${{ steps.config.outputs.build_from }}
-            librtlsdrRepo=${{ steps.config.outputs.librtlsdr_repo }}
+            librtlsdrGitRevision=${{ steps.config.outputs.librtlsdr_git_revision }}
             rtl433GitRevision=${{ steps.config.outputs.rtl433_git_revision }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,8 @@ jobs:
   lint:
     name: Lint add-on
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           echo "build_from=$(yq ".build_from.${ARCH}" build.yaml)" >> $GITHUB_OUTPUT
-          echo "librtlsdr_repo=$(yq '.args.librtlsdrRepo' build.yaml)" >> $GITHUB_OUTPUT
+          echo "librtlsdr_git_revision=$(yq '.args.librtlsdrGitRevision' build.yaml)" >> $GITHUB_OUTPUT
           echo "rtl433_git_revision=$(yq '.args.rtl433GitRevision' build.yaml)" >> $GITHUB_OUTPUT
           echo "version=$(yq '.version' config.yaml)" >> $GITHUB_OUTPUT
 
@@ -65,5 +65,5 @@ jobs:
           version: ${{ steps.config.outputs.version }}
           build-args: |
             BUILD_FROM=${{ steps.config.outputs.build_from }}
-            librtlsdrRepo=${{ steps.config.outputs.librtlsdr_repo }}
+            librtlsdrGitRevision=${{ steps.config.outputs.librtlsdr_git_revision }}
             rtl433GitRevision=${{ steps.config.outputs.rtl433_git_revision }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     name: Initialize build
+    permissions: {}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/update-repository.yaml
+++ b/.github/workflows/update-repository.yaml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: 📢 Publish Add-on
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: 🚀 Dispatch Repository Updater update signal
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ WORKDIR /build
 # --- Stage: Build librtlsdr ---
 FROM builder as librtlsdr_builder
 
-ARG librtlsdrRepo=https://github.com/librtlsdr/librtlsdr
+ARG librtlsdrGitRevision=cd36c28815592af4080d71181964909125a74f44 # v0.9.0
 
 WORKDIR /build
-RUN git clone ${librtlsdrRepo}
+RUN git clone https://github.com/librtlsdr/librtlsdr
 WORKDIR /build/librtlsdr
 
-RUN git checkout master
+RUN git checkout ${librtlsdrGitRevision}
 
 # Build and install to staging root
 RUN mkdir build && cd build && \
@@ -43,7 +43,7 @@ WORKDIR /build
 RUN git clone https://github.com/merbanan/rtl_433
 WORKDIR /build/rtl_433
 
-ARG rtl433GitRevision=25.02
+ARG rtl433GitRevision=ea7d504877df751a202432d47dbb0c425ab0a93c # 25.12
 RUN git checkout ${rtl433GitRevision}
 
 # Build and install to staging root

--- a/build.yaml
+++ b/build.yaml
@@ -2,5 +2,5 @@ build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
   amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
 args:
-  librtlsdrRepo: "https://github.com/librtlsdr/librtlsdr"
-  rtl433GitRevision: "25.02"
+  librtlsdrGitRevision: "cd36c28815592af4080d71181964909125a74f44" # v0.9.0
+  rtl433GitRevision: "ea7d504877df751a202432d47dbb0c425ab0a93c" # 25.12


### PR DESCRIPTION
## Summary

- **rtl_433** updated from 25.02 → 25.12, pinned to commit SHA `ea7d504`
- **librtlsdr** pinned to v0.9.0 (`cd36c28`) — was previously unpinned on `master`
- Repo URLs hardcoded in Dockerfile; `build.yaml` is now the single source of truth for revisions only
- Replaced `librtlsdrRepo` build arg with `librtlsdrGitRevision` across Dockerfile, build.yaml, and both workflows

### Why

Git tags can be moved and branches change with every push. Pinning to commit SHAs ensures reproducible builds. The `# tag` comments preserve readability.

## Test plan

- [ ] CI workflow builds successfully on this PR
- [ ] Verify both `librtlsdr` and `rtl_433` check out the correct commits